### PR TITLE
fix: add id-token permission for Claude Code action

### DIFF
--- a/.github/workflows/dependabot-review.yml
+++ b/.github/workflows/dependabot-review.yml
@@ -8,6 +8,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   # Only run for Dependabot PRs
@@ -60,4 +61,3 @@ jobs:
 
             Do NOT approve or merge the PR - leave that to humans.
           claude_args: "--max-turns 15 --model claude-sonnet-4-5-20250929"
-          allowed_tools: "Bash,Read,Edit,Write,Glob,Grep"


### PR DESCRIPTION
## Summary
- Add `id-token: write` permission required for OIDC authentication with claude-code-action
- Remove `allowed_tools` parameter which is not valid for this action

## Problem
The Dependabot review workflow was failing with:
```
Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
```

## Test plan
- [ ] Merge this PR
- [ ] Run `@dependabot rebase` on PR #5 to trigger the workflow
- [ ] Verify the review workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)