### PR TITLE
fix: allow dependabot[bot] to trigger Claude review

### DIFF
--- a/.github/workflows/dependabot-review.yml
+++ b/.github/workflows/dependabot-review.yml
@@ -61,3 +61,4 @@ jobs:
 
             Do NOT approve or merge the PR - leave that to humans.
           claude_args: "--max-turns 15 --model claude-sonnet-4-5-20250929"
+          allowed_bots: "dependabot[bot]"


### PR DESCRIPTION
## Summary
Add `allowed_bots: "dependabot[bot]"` to permit Dependabot PRs to be reviewed by Claude Code action.

## Problem
The workflow was failing with:
```
Workflow initiated by non-human actor: dependabot (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.
```

## Test plan
- [ ] Merge this PR
- [ ] Run `@dependabot rebase` on PR #5 to trigger the workflow
- [ ] Verify Claude successfully reviews the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)