### PR TITLE
feat: enable sticky comment for Claude review results

### DIFF
--- a/.github/workflows/dependabot-review.yml
+++ b/.github/workflows/dependabot-review.yml
@@ -62,3 +62,4 @@ jobs:
             Do NOT approve or merge the PR - leave that to humans.
           claude_args: "--max-turns 15 --model claude-sonnet-4-5-20250929"
           allowed_bots: "dependabot[bot]"
+          use_sticky_comment: true


### PR DESCRIPTION
## Summary
Add `use_sticky_comment: true` to post Claude's review summary directly to the PR as a comment.

## What this enables
- Claude's review analysis will be posted as a **PR comment** (visible to all reviewers)
- The comment is "sticky" - it gets updated on each push instead of creating new comments
- No more digging through workflow logs to see the review

## Current behavior
Claude generates a detailed review but it's only visible in the GitHub Actions workflow logs/summary.

## Test plan
- [ ] Merge this PR
- [ ] Run `@dependabot rebase` on PR #5
- [ ] Verify Claude posts a comment on the PR with the review summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)