### PR TITLE
fix: add bash permissions and increase max turns for Claude review

### DIFF
--- a/.github/workflows/dependabot-review.yml
+++ b/.github/workflows/dependabot-review.yml
@@ -60,6 +60,12 @@ jobs:
                - Your recommendation (safe to merge / needs attention)
 
             Do NOT approve or merge the PR - leave that to humans.
-          claude_args: "--max-turns 15 --model claude-sonnet-4-5-20250929"
+          claude_args: "--max-turns 25 --model claude-sonnet-4-5-20250929"
           allowed_bots: "dependabot[bot]"
           use_sticky_comment: true
+          additional_permissions: |
+            - "run yarn commands for installing and testing"
+            - "run poetry commands for installing and testing"
+            - "run curl for health checks"
+            - "run gh commands for PR operations"
+            - "run node and python for testing"


### PR DESCRIPTION
## Summary
- Add `additional_permissions` to allow Claude to run the necessary bash commands
- Increase `max-turns` from 15 to 25 to give Claude enough turns to complete reviews

## Problem
Claude was hitting the max turns limit (15) because many bash commands were being denied:
- `yarn install/start` - needed for Node.js testing
- `poetry install/run` - needed for Python testing  
- `curl` - needed for health checks
- `gh pr` - needed for PR operations

## Changes
```yaml
additional_permissions: |
  - "run yarn commands for installing and testing"
  - "run poetry commands for installing and testing"
  - "run curl for health checks"
  - "run gh commands for PR operations"
  - "run node and python for testing"
```

## Test plan
- [ ] Merge this PR
- [ ] Run `@dependabot rebase` on PR #5
- [ ] Verify Claude completes the review and posts a comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)